### PR TITLE
Check only binaries when in a tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-fslabscli"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2021"
 authors = ["FSLABS DevOps Gods"]
 repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"

--- a/src/commands/check_workspace/mod.rs
+++ b/src/commands/check_workspace/mod.rs
@@ -511,9 +511,14 @@ pub async fn check_workspace(
                 if let Ok(env_string) = std::env::var("GITHUB_REF") {
                     // Regarding installer and launcher, we need to check the tag of their counterpart
                     if env_string.starts_with("refs/tags") {
-                        if package_key.ends_with("_launcher") || package_key.ends_with("_installer")
-                        {
-                        } else {
+                        let mut check_key = package_key.clone();
+                        if package_key.ends_with("_launcher") {
+                            check_key = check_key.replace("_launcher", "");
+                        }
+                        if package_key.ends_with("_installer") {
+                            check_key = check_key.replace("_installer", "");
+                        }
+                        if !env_string.starts_with(&format!("refs/tags/{}", check_key)) {
                             package.publish = false;
                         }
                     }


### PR DESCRIPTION
When the environment variable GITHUB_REF is fed in, and it has a tag. We are only interested in the launchers.

Set all non binary application publishes to false