### PR TITLE
fix(nix): enable `nix run .`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -109,22 +109,7 @@
           let
             inherit (arch2targets.${system}) rustTarget;
           in
-          (craneLib.buildPackage (
-            (generateCommonArgs craneLib)
-            // {
-              postInstall = ''
-                cd "$out"/bin
-                for f in "$(ls)"; do
-                  if ext="$(echo "$f" | grep -oP '\.[a-z]+$')"; then
-                    base="$(echo "$f" | cut -d. -f1)"
-                    mv "$f" "$base-${rustTarget}$ext"
-                  else
-                    mv "$f" "$f-${rustTarget}"
-                  fi
-                done
-              '';
-            }
-          ));
+          (craneLib.buildPackage (generateCommonArgs craneLib));
 
         mkCrossRustPackage =
           arch: packageName:


### PR DESCRIPTION
I tried  `nix run .` to open the tool and I hit an error where the binary was suffixed with the Rust target that is unexpected.

```
error: unable to execute '/nix/store/96dchy6m0psj45rxlya8ar55bb3rv1vx-cargo-fslabscli-2.25.1/bin/cargo-fslabscli': No such file or directory

[nix-shell:~/work/fsl/fslabscli]$ ls /nix/store/96dchy6m0psj45rxlya8ar55bb3rv1vx-cargo-fslabscli-2.25.1/bin
cargo-fslabscli-x86_64-unknown-linux-musl
```

In this PR, I removed the code that renamed the binary for the same-arch build. I'm not sure if the `flake.nix` is being formatted by a tool.