### PR TITLE
don't mark unknown crates as existing

### DIFF
--- a/src/utils/cargo.rs
+++ b/src/utils/cargo.rs
@@ -233,7 +233,7 @@ impl Cargo {
 
             if res.status().as_u16() == 404 {
                 // New crates
-                return Ok(true);
+                return Ok(false);
             }
             if res.status().as_u16() >= 400 {
                 anyhow::bail!(


### PR DESCRIPTION
Fixes #89 

crates that are not yet found in a registry are not marked as existing