### PR TITLE
fix: set current_dir for pre_test_script

### DIFF
--- a/src/commands/tests/mod.rs
+++ b/src/commands/tests/mod.rs
@@ -577,6 +577,7 @@ async fn do_test_on_package(
         let start_time = OffsetDateTime::now_utc();
         let mut script = Script::new(pre_test_script)
             .name("pre_test_script")
+            .current_dir(&package_path)
             .log_stdout(tracing::Level::INFO)
             .log_stderr(tracing::Level::INFO);
         if let Some(url) = &database_url {


### PR DESCRIPTION
This should fix CI against fsl_libs. I'm running the CLI locally and it's going well so far.