### PR TITLE
fix: correct env/env_remove order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.30.2"
+version = "2.30.3"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-fslabscli"
 publish = ["foresight_mining_software_corporation"]
 repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"
-version = "2.30.2"
+version = "2.30.3"
 
 [package.metadata.fslabs.publish.binary]
 name = "FSLABS Cli tool"

--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1759511609,
-        "narHash": "sha256-uU6Dq5OUgI9pEiMDwZZhvsoxYD+36xKIkYyFXDr//6A=",
+        "lastModified": 1759893430,
+        "narHash": "sha256-yAy4otLYm9iZ+NtQwTMEbqHwswSFUbhn7x826RR6djw=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "c5b48a59ccd5179ea626f47b05d2828c37fb31b7",
+        "rev": "1979a2524cb8c801520bd94c38bb3d5692419d93",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1759501127,
-        "narHash": "sha256-V9N8Q0Nm9v9A02xD3ujLUCR9JzvLJVuOefXQ4nw2+zM=",
+        "lastModified": 1760394278,
+        "narHash": "sha256-AibI6iJtlD+y532sLIitI1xZ5G6PEw+qsJ2o8vflma4=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "a9f2a642628e2021e393cd4c6070d64d23a3f70f",
+        "rev": "d786b5f55ad14a7078057779e7bf016e38311e66",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1759473677,
-        "narHash": "sha256-9AFDP5AhXe06aXXPsV7bDGH7KA9Wo4uUtK7pRrsxuFQ=",
+        "lastModified": 1760424233,
+        "narHash": "sha256-8jLfVik1ccwmacVW5BlprmsuK534rT5HjdPhkSaew44=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "8532b07ced6a95d57650124c79534a3c770431ab",
+        "rev": "48a763cdc0b2d07199a021de99c2ca50af76e49f",
         "type": "github"
       },
       "original": {
@@ -268,11 +268,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1759381078,
-        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
+        "lastModified": 1760284886,
+        "narHash": "sha256-TK9Kr0BYBQ/1P5kAsnNQhmWWKgmZXwUQr4ZMjCzWf2c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
+        "rev": "cf3f5c4def3c7b5f1fc012b3d839575dbe552d43",
         "type": "github"
       },
       "original": {
@@ -298,11 +298,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1759381078,
-        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
+        "lastModified": 1760284886,
+        "narHash": "sha256-TK9Kr0BYBQ/1P5kAsnNQhmWWKgmZXwUQr4ZMjCzWf2c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
+        "rev": "cf3f5c4def3c7b5f1fc012b3d839575dbe552d43",
         "type": "github"
       },
       "original": {
@@ -325,11 +325,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1759301569,
-        "narHash": "sha256-7StxDed3v2fAWLkl+Hse9FlpjT7Dk7Cn/4vxTFyEhIg=",
+        "lastModified": 1760260966,
+        "narHash": "sha256-pOVvZz/aa+laeaUKyE6PtBevdo4rywMwjhWdSZE/O1c=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "472037b789cf593172d6adf3b8d9f7a429f6cd9b",
+        "rev": "c5181dbbe33af6f21b9d83e02fdb6fda298a3b65",
         "type": "github"
       },
       "original": {

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -590,8 +590,8 @@ async fn do_publish_package(
             let build_command = package.publish_detail.s3.build_command;
             let command_output = Script::new(&build_command)
                 .current_dir(&package_path)
-                .envs(&envs)
                 .env_removals(&blacklist_envs)
+                .envs(&envs)
                 .log_stdout(tracing::Level::INFO)
                 .log_stderr(tracing::Level::INFO)
                 .execute()
@@ -804,7 +804,6 @@ async fn do_publish_package(
                                     blacklist_envs.insert(key);
                                 }
                             }
-
                             let mut args = vec![
                                 additional_args.clone(),
                                 "--registry".to_string(),
@@ -814,15 +813,17 @@ async fn do_publish_package(
                             if options.dry_run {
                                 args.push("--dry-run".to_string())
                             }
-                            let command_output =
-                                Script::new(format!("cargo publish {}", args.join(" ")))
-                                    .current_dir(&package_path)
-                                    .envs(&envs)
-                                    .env_removals(&blacklist_envs)
-                                    .log_stdout(tracing::Level::INFO)
-                                    .log_stderr(tracing::Level::INFO)
-                                    .execute()
-                                    .await;
+                            let command_output = Script::new(format!(
+                                "printenv | grep CARGO && cargo publish {}",
+                                args.join(" ")
+                            ))
+                            .current_dir(&package_path)
+                            .env_removals(&blacklist_envs)
+                            .envs(&envs)
+                            .log_stdout(tracing::Level::INFO)
+                            .log_stderr(tracing::Level::INFO)
+                            .execute()
+                            .await;
                             r.update_from_command(command_output);
                         } else {
                             r.success = false;
@@ -948,8 +949,8 @@ async fn do_publish_package(
                 args.join(" ")
             ))
             .current_dir(&repo_root)
-            .envs(&envs)
             .env_removals(&blacklist_envs)
+            .envs(&envs)
             .log_stdout(tracing::Level::INFO)
             .log_stderr(tracing::Level::INFO)
             .execute()


### PR DESCRIPTION
We should first remove blacklisted env, then add new ones