### PR TITLE
feat: plumb test env into custom services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.30.8"
+version = "2.30.9"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-fslabscli"
 publish = ["foresight_mining_software_corporation"]
 repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"
-version = "2.30.8"
+version = "2.30.9"
 
 [package.metadata.fslabs.publish.binary]
 name = "FSLABS Cli tool"

--- a/src/script.rs
+++ b/src/script.rs
@@ -67,6 +67,13 @@ impl Script {
         self
     }
 
+    pub fn maybe_env(mut self, key: impl AsRef<OsStr>, value: Option<impl AsRef<OsStr>>) -> Self {
+        if let Some(value) = value {
+            self.inner.env(key, value);
+        }
+        self
+    }
+
     pub fn envs<I, K, V>(mut self, vars: I) -> Self
     where
         I: IntoIterator<Item = (K, V)>,


### PR DESCRIPTION
Turns out we need these env vars for custom services. Might as well add them to the pre-test script too.