### PR TITLE
fix: remove bad copy-pasted options for minio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.32.1"
+version = "2.32.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -1102,7 +1102,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "fsl_test_api"
-version = "2.30.0"
+version = "2.32.0"
 dependencies = [
  "envconfig",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-fslabscli"
 publish = ["foresight_mining_software_corporation"]
 repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"
-version = "2.32.1"
+version = "2.32.2"
 
 [package.metadata.fslabs.publish.binary]
 name = "FSLABS Cli tool"

--- a/crates/fsl_test_api/Cargo.toml
+++ b/crates/fsl_test_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsl_test_api"
-version = "2.30.0"
+version = "2.32.0"
 description = "API for use within tests that depend on the fslabscli test runner"
 authors = ["FSLABS DevOps Gods"]
 edition = "2024"

--- a/crates/fsl_test_api/src/lib.rs
+++ b/crates/fsl_test_api/src/lib.rs
@@ -2,7 +2,7 @@ use envconfig::Envconfig;
 use url::Url;
 
 /// Environment variables created by the test runner for use in tests.
-#[derive(Envconfig)]
+#[derive(Clone, Debug, Envconfig, Eq, PartialEq)]
 pub struct FslTestEnv {
     /// The URL used for connecting to the Postgres service.
     ///

--- a/src/commands/tests/docker_service.rs
+++ b/src/commands/tests/docker_service.rs
@@ -7,7 +7,6 @@ pub struct DockerContainer {
     pub prefix: String,
     pub env: String,
     pub port: String,
-    pub options: String,
     pub image: String,
     pub command: String,
 }
@@ -18,7 +17,6 @@ impl DockerContainer {
             prefix: "azurite".into(),
             env: "".into(),
             port: format!("-p {blob_port}:10000"),
-            options: "".into(),
             image: "mcr.microsoft.com/azure-storage/azurite".into(),
             command: Default::default(),
         }
@@ -29,9 +27,8 @@ impl DockerContainer {
             prefix: "minio".into(),
             env: "-e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin".into(),
             port: format!("-p {service_port}:9000"),
-            options: "server /data --console-address :9001".into(),
             image: "minio/minio:latest".into(),
-            command: "server /data --address=0.0.0.0:9000".into(),
+            command: "server /data".into(),
         }
     }
 
@@ -40,7 +37,6 @@ impl DockerContainer {
             prefix: "postgres".into(),
             env: format!("-e POSTGRES_PASSWORD={DB_PASSWORD} -e POSTGRES_DB={DB_NAME}"),
             port: format!("-p {port}:5432"),
-            options: "".into(),
             image: "postgres:alpine".into(),
             command: Default::default(),
         }
@@ -51,7 +47,6 @@ impl DockerContainer {
             prefix,
             env,
             port,
-            options,
             image,
             command,
         } = self;
@@ -59,7 +54,7 @@ impl DockerContainer {
         let container_name = format!("{prefix}_{suffix}");
         let path = std::env::current_dir().unwrap();
         let command_output = Script::new(format!(
-            "docker run --name={container_name} -d {env} {port} {options} {image} {command}"
+            "docker run --name={container_name} -d {env} {port} {image} {command}"
         ))
         .current_dir(&path)
         .execute()


### PR DESCRIPTION
I messed up [this refactor](https://github.com/ForesightMiningSoftwareCorporation/fslabscli/pull/218/commits/fc8af3cc00ecc000d528c5f0b7b1989f9dcd8f00).

This PR fixes that mistake.