### PR TITLE
feat(publish): add --publish-steps CLI override and auto-read version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.43.0"
+version = "2.44.0"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-fslabscli"
 publish = ["fsl"]
 repository = "https://github.com/fslabs/fslabsci"
-version = "2.43.0"
+version = "2.44.0"
 
 [package.metadata.fslabs.publish.binary]
 name = "FSLABS Cli tool"

--- a/src/commands/draft_release/mod.rs
+++ b/src/commands/draft_release/mod.rs
@@ -44,6 +44,7 @@ pub struct Options {
     #[arg(long, env, default_value = "")]
     pub package_name: String,
     /// Package version, used together with `--tag-format` when `--release-tag` is absent.
+    /// Defaults to the version field in Cargo.toml when not provided.
     #[arg(long, env, default_value = "")]
     pub version: String,
     /// Release title. Defaults to the tag name when not set.
@@ -158,11 +159,8 @@ async fn find_or_create_draft_release(
 /// Validates the combination of options before any I/O is performed.
 ///
 /// Returns an error describing the first violated constraint, if any.
+/// Note: empty `version` is allowed here — the caller falls back to Cargo.toml.
 pub fn validate_options(options: &Options) -> anyhow::Result<()> {
-    if options.release_tag.is_none() && options.version.is_empty() {
-        anyhow::bail!("--version or --release-tag is required");
-    }
-
     if options.release_tag.is_none()
         && options.tag_format.contains("{package_name}")
         && options.package_name.is_empty()
@@ -173,10 +171,28 @@ pub fn validate_options(options: &Options) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Reads version and package name from the root package in Cargo.toml.
+fn read_cargo_metadata(working_directory: &PathBuf) -> anyhow::Result<(String, String)> {
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .current_dir(working_directory)
+        .no_deps()
+        .exec()
+        .context("Failed to read Cargo.toml metadata")?;
+
+    let root_package = metadata
+        .root_package()
+        .context("No root package found in Cargo.toml")?;
+
+    Ok((
+        root_package.version.to_string(),
+        root_package.name.to_string(),
+    ))
+}
+
 /// Creates or updates a draft GitHub release and uploads all files from the artifacts directory.
 pub async fn draft_release(
-    options: Box<Options>,
-    _working_directory: PathBuf,
+    mut options: Box<Options>,
+    working_directory: PathBuf,
 ) -> anyhow::Result<DraftReleaseResult> {
     let (Some(github_app_id), Some(github_app_private_key)) = (
         options.github_app_id,
@@ -186,6 +202,16 @@ pub async fn draft_release(
     };
 
     validate_options(&options)?;
+
+    // Fall back to Cargo.toml when version (or package name) is not supplied and no
+    // explicit release tag was given — both are needed to derive the tag from the format.
+    if options.release_tag.is_none() && options.version.is_empty() {
+        let (cargo_version, cargo_name) = read_cargo_metadata(&working_directory)?;
+        options.version = cargo_version;
+        if options.package_name.is_empty() {
+            options.package_name = cargo_name;
+        }
+    }
 
     let tag = match &options.release_tag {
         Some(explicit) => explicit.clone(),
@@ -272,25 +298,19 @@ mod tests {
     }
 
     #[test]
-    fn should_error_when_release_tag_absent_and_version_empty() {
-        // Arrange
+    fn should_pass_when_release_tag_absent_and_version_empty() {
+        // validate_options no longer rejects an empty version — the caller falls back
+        // to reading the version from Cargo.toml in that case.
         let options = Options {
             release_tag: None,
             version: String::new(),
+            tag_format: "v{version}".to_string(), // no {package_name} → no other constraint
             ..base_options()
         };
 
-        // Act
         let result = validate_options(&options);
 
-        // Assert
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("--version or --release-tag is required")
-        );
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -103,6 +103,21 @@ pub struct Options {
     /// Intended for Prow/CI invocations on push to main where no git tag exists yet.
     #[arg(long, env)]
     release_tag: Option<String>,
+    /// Override which publish steps to run, ignoring Cargo.toml metadata.
+    /// Can be repeated: --publish-steps nix --publish-steps cargo
+    /// When omitted, all steps enabled in Cargo.toml metadata run (current behavior).
+    #[arg(long, env, value_delimiter = ',')]
+    pub publish_steps: Option<Vec<PublishStep>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, clap::ValueEnum)]
+pub enum PublishStep {
+    S3,
+    Cargo,
+    Nix,
+    Docker,
+    Tags,
+    Github,
 }
 
 #[derive(Serialize, Default, Clone)]
@@ -657,6 +672,17 @@ struct DoPublishParams {
     member_paths: Arc<Vec<PathBuf>>,
 }
 
+/// Returns true if the given publish step should execute.
+///
+/// When `--publish-steps` is provided, only the explicitly listed steps run.
+/// When omitted, falls back to `metadata_enabled` (the Cargo.toml-derived value).
+fn should_run_step(options: &Options, step: PublishStep, metadata_enabled: bool) -> bool {
+    match &options.publish_steps {
+        Some(steps) => steps.contains(&step),
+        None => metadata_enabled,
+    }
+}
+
 /// Actual Publish
 async fn do_publish_package(params: DoPublishParams) -> PublishResult {
     let DoPublishParams {
@@ -680,7 +706,7 @@ async fn do_publish_package(params: DoPublishParams) -> PublishResult {
     let package_name = &package.package;
     let package_path = repo_root.join(&package.path);
     let mut is_failed = false;
-    if !is_failed && package.publish_detail.s3.publish {
+    if !is_failed && should_run_step(&options, PublishStep::S3, package.publish_detail.s3.publish) {
         result.s3.start_time = Some(SystemTime::now());
         if options.dry_run {
             result.s3.success = true;
@@ -869,7 +895,13 @@ async fn do_publish_package(params: DoPublishParams) -> PublishResult {
         }
         result.s3.end_time = Some(SystemTime::now());
     }
-    if !is_failed && package.publish_detail.cargo.publish {
+    if !is_failed
+        && should_run_step(
+            &options,
+            PublishStep::Cargo,
+            package.publish_detail.cargo.publish,
+        )
+    {
         let additional_args = package.publish_detail.additional_args.unwrap_or_default();
 
         if let Some(original_registry) = cargo.get_registry(&common_options.cargo_main_registry) {
@@ -1029,7 +1061,13 @@ async fn do_publish_package(params: DoPublishParams) -> PublishResult {
             }
         }
     }
-    if !is_failed && package.publish_detail.nix_binary.publish {
+    if !is_failed
+        && should_run_step(
+            &options,
+            PublishStep::Nix,
+            package.publish_detail.nix_binary.publish,
+        )
+    {
         result.nix_binary.start_time = Some(SystemTime::now());
         if options.dry_run {
             result.nix_binary.success = true;
@@ -1094,7 +1132,13 @@ async fn do_publish_package(params: DoPublishParams) -> PublishResult {
         }
         result.nix_binary.end_time = Some(SystemTime::now());
     }
-    if !is_failed && package.publish_detail.docker.publish {
+    if !is_failed
+        && should_run_step(
+            &options,
+            PublishStep::Docker,
+            package.publish_detail.docker.publish,
+        )
+    {
         result.docker.start_time = Some(SystemTime::now());
         if options.dry_run {
             result.docker.success = true;
@@ -1205,7 +1249,7 @@ async fn do_publish_package(params: DoPublishParams) -> PublishResult {
         }
         result.docker.end_time = Some(SystemTime::now());
     }
-    if !is_failed && result.git_tag.should_publish {
+    if !is_failed && should_run_step(&options, PublishStep::Tags, result.git_tag.should_publish) {
         result.git_tag.start_time = Some(SystemTime::now());
         let tagged: anyhow::Result<()> = async {
             let tag = format_tag(&options.tag_format, &package.package, &package.version);
@@ -1652,9 +1696,11 @@ pub async fn publish(
     futures::future::join_all(handles).await;
 
     // Report publish result to github
-    report_publish_to_github(common_options, options, &artifact_dir, &repo_root)
-        .await
-        .with_context(|| "Failed to report publish results to GitHub")?;
+    if should_run_step(options, PublishStep::Github, true) {
+        report_publish_to_github(common_options, options, &artifact_dir, &repo_root)
+            .await
+            .with_context(|| "Failed to report publish results to GitHub")?;
+    }
 
     let mut global_success = true;
     let mut published_members = HashMap::new();


### PR DESCRIPTION
- Add --publish-steps flag to override Cargo.toml metadata per step (s3, cargo, nix, docker, tags, github)
- Auto-read version and package name from Cargo.toml in draft-release when not explicitly provided
- Fix clippy: &PathBuf → &Path in report_publish_to_github