### PR TITLE
feat(publish): musl static builds, draft release tag fallback, release notes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       devenv,
       ...
     }:
-    flake-utils.lib.eachDefaultSystem (
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-darwin" ] (
       system:
       let
         overlays = [ ];
@@ -24,7 +24,7 @@
           inherit system overlays;
           stdenv = nixpkgs.clangStdenv;
         };
-        inherit (pkgs.stdenv) isDarwin;
+        inherit (pkgs.stdenv) isDarwin isLinux;
         lib = pkgs.lib;
         fenixPkgs = fenix.packages.${system};
         toolchain = fenixPkgs.fromToolchainFile {
@@ -106,10 +106,25 @@
         mkRustPackage =
           packageName:
           let
-            inherit (arch2targets.${system}) rustTarget;
+            inherit (arch2targets.${system}) rustTarget pkgsCross depsBuildBuild;
+            TARGET_CC = if isLinux then
+              "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc"
+            else
+              "";
+            linuxStaticArgs = lib.optionalAttrs isLinux {
+              inherit TARGET_CC depsBuildBuild;
+              CARGO_BUILD_TARGET = rustTarget;
+              CARGO_BUILD_RUSTFLAGS = [
+                "-C" "linker=${TARGET_CC}"
+                "-C" "target-feature=+crt-static"
+              ];
+              CC = TARGET_CC;
+              LD = TARGET_CC;
+            };
           in
           (craneLib.buildPackage (
             (generateCommonArgs craneLib)
+            // linuxStaticArgs
             // {
               postInstall = ''
                 cd "$out"/bin

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 profile = "default"
 channel = "1.93"
-targets = ["aarch64-apple-darwin", "wasm32-unknown-unknown" ]
+targets = ["aarch64-apple-darwin", "wasm32-unknown-unknown", "x86_64-unknown-linux-musl"]

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -1607,15 +1607,37 @@ pub async fn report_publish_to_github(
                 base_rev.to_string()
             } else {
                 // base_rev is a commit reference, resolve it to a tag
-                let resolved_tag =
-                    resolve_commit_to_tag(repo_root, base_rev, &options.tag_pattern)?;
-                tracing::info!(
-                    "Resolved commit {} to tag: {} (pattern: {})",
-                    base_rev,
-                    resolved_tag,
-                    options.tag_pattern
-                );
-                resolved_tag
+                match resolve_commit_to_tag(repo_root, base_rev, &options.tag_pattern) {
+                    Ok(resolved_tag) => {
+                        tracing::info!(
+                            "Resolved commit {} to tag: {} (pattern: {})",
+                            base_rev,
+                            resolved_tag,
+                            options.tag_pattern
+                        );
+                        resolved_tag
+                    }
+                    Err(e) if options.draft => {
+                        // Draft mode without a git tag (e.g. --publish-steps nix,github skips cargo/tagging).
+                        // Compute the expected release tag from Cargo.toml + tag_format.
+                        tracing::info!(
+                            "No tag found on {} ({}); computing tag from Cargo.toml for draft release",
+                            base_rev,
+                            e
+                        );
+                        let manifest: toml::Value = toml::from_str(
+                            &std::fs::read_to_string(repo_root.join("Cargo.toml"))
+                                .with_context(|| "Failed to read workspace Cargo.toml")?,
+                        )
+                        .with_context(|| "Failed to parse workspace Cargo.toml")?;
+                        let version = manifest["package"]["version"].as_str().unwrap_or("0.0.0");
+                        let package_name = manifest["package"]["name"].as_str().unwrap_or("");
+                        let tag = format_tag(&options.tag_format, package_name, version);
+                        tracing::info!("Computed draft release tag: {}", tag);
+                        tag
+                    }
+                    Err(e) => return Err(e),
+                }
             }
         };
 
@@ -1657,28 +1679,45 @@ pub async fn report_publish_to_github(
                                 "No draft release found for tag {}, creating one",
                                 release_tag
                             );
-                            repo_releases
-                                .create(&release_tag)
-                                .draft(true)
-                                .send()
-                                .await
-                                .with_context(|| {
+                            {
+                                let notes = repo_releases
+                                    .generate_release_notes(&release_tag)
+                                    .target_commitish("main")
+                                    .send()
+                                    .await
+                                    .ok();
+                                let mut builder = repo_releases
+                                    .create(&release_tag)
+                                    .name(&release_tag)
+                                    .draft(true);
+                                if let Some(notes) = &notes {
+                                    builder = builder.body(&notes.body);
+                                }
+                                builder.send().await.with_context(|| {
                                     format!(
                                         "Failed to create draft release for tag: {}",
                                         release_tag
                                     )
                                 })?
+                            }
                         }
                     }
                 } else {
                     tracing::info!("No existing release for tag {}, creating one", release_tag);
-                    repo_releases
-                        .create(&release_tag)
-                        .send()
-                        .await
-                        .with_context(|| {
+                    {
+                        let notes = repo_releases
+                            .generate_release_notes(&release_tag)
+                            .send()
+                            .await
+                            .ok();
+                        let mut builder = repo_releases.create(&release_tag).name(&release_tag);
+                        if let Some(notes) = &notes {
+                            builder = builder.body(&notes.body);
+                        }
+                        builder.send().await.with_context(|| {
                             format!("Failed to create release for tag: {}", release_tag)
                         })?
+                    }
                 }
             }
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -416,7 +416,7 @@ async fn main() -> ExitCode {
             0
         }
         Err(e) => {
-            tracing::error!("Could not execute command: {}", e);
+            tracing::error!("Could not execute command: {:#}", e);
             1
         }
     };


### PR DESCRIPTION
## Summary
- **feat(nix)**: Add musl static cross-compilation for linux releases, restrict flake systems to x86_64-linux + aarch64-darwin
- **fix(publish)**: Compute draft release tag from Cargo.toml when no git tag exists on HEAD (fixes `--publish-steps nix,github` without cargo tagging step)
- **fix(publish)**: Set release name and auto-generate release notes when creating GitHub releases
- **fix(main)**: Use `{:#}` for error display to show full anyhow error chain

## Test plan
- [x] Nix build succeeds on x86_64-linux remote builder
- [x] Draft release created with correct tag (`v2.45.0`)
- [x] Assets uploaded to draft release
- [ ] Prow `cargo-tests` presubmit passes
- [ ] Canary promotion test