### PR TITLE
chore: bump version to 2.46.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.45.0"
+version = "2.46.0"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-fslabscli"
 publish = ["fsl"]
 repository = "https://github.com/fslabs/fslabsci"
-version = "2.45.0"
+version = "2.46.0"
 
 [package.metadata.fslabs.publish.binary]
 name = "FSLABS Cli tool"


### PR DESCRIPTION
Bumps `version` from 2.45.0 to 2.46.0 in `Cargo.toml` and `Cargo.lock`. Minor bump for the two `feat` commits landed on `main` since v2.45.0.