### PR TITLE
feat(tests): give annotations a credential, and say why when they are skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,38 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 To install, run the following command:
 ``cargo install --git https://github.com/fslabs/fslabscli``
 
+## Test annotations
+
+`fslabscli rust-tests` posts the `file:line` locations of cargo failures as a
+`test-annotations` GitHub check run, so they render inline on the pull request's
+*Files changed* tab. The conclusion is always `neutral` — this reports
+locations, not a verdict, and the CI job's own check remains the pass/fail gate.
+Posting never fails the build: if it cannot post, it logs a warning saying why.
+
+It needs to know which commit to annotate. Prow injects these into every
+decorated job, so there is nothing to configure in CI:
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `REPO_OWNER` | yes | Repository owner |
+| `REPO_NAME` | yes | Repository name |
+| `PULL_PULL_SHA` | yes | Commit to attach the check run to; falls back to `PULL_BASE_SHA` |
+| `PULL_NUMBER` | no | Links findings into the PR diff rather than the blob view |
+| `FSLABSCLI_ANNOTATIONS_DISABLE` | no | Set to `1` or `true` to turn posting off |
+
+It also needs a credential with the `checks: write` permission, from one of:
+
+| Variable | Purpose |
+|---|---|
+| `GITHUB_TOKEN` | Used directly when present |
+| `FSLABSCLI_CHECKS_APP_ID` + `FSLABSCLI_CHECKS_APP_PRIVATE_KEY` | App ID and private-key path; mints a token scoped to the repository under test |
+
+Prefer the App in CI. A test job compiles and runs unreviewed pull-request code,
+so any credential it holds should be assumed readable by that code; an
+installation token scoped to one repository and holding only `checks: write` is
+far less useful to an attacker than a broadly-scoped one. The private key must
+belong to an app installed on the repository being tested.
+
 ## Release Process
 
 **Version source of truth:** `Cargo.toml`

--- a/src/commands/tests/annotations.rs
+++ b/src/commands/tests/annotations.rs
@@ -719,6 +719,31 @@ fn build_summary(ctx: &GhTarget, annotations: &[Annotation], junit: &Report) -> 
     out
 }
 
+// Credentials that occasionally turn up in build output. The common one is the
+// URL rewrite CI installs to clone private dependencies, which puts a token in
+// the userinfo of every git URL a failing fetch might echo.
+static URL_CREDENTIAL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"://([^/\s:@]+):[^@\s]+@").unwrap());
+static GITHUB_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"gh[pousr]_[A-Za-z0-9]{16,}|github_pat_[A-Za-z0-9_]{20,}").unwrap()
+});
+
+/// Strip well-known credential shapes out of text taken from build output.
+///
+/// Annotations are copied verbatim from compiler and build-tool output into a
+/// check run, which anyone who can see the pull request can read - and some of
+/// the repositories this runs on are public. Prow censors what it uploads to
+/// its own log store, but nothing censors what we POST to GitHub.
+///
+/// This is a backstop for the shapes we can recognise, not a guarantee that no
+/// secret can ever reach a check run.
+fn redact(text: &str) -> String {
+    let without_url_creds = URL_CREDENTIAL_RE.replace_all(text, "://$1:REDACTED@");
+    GITHUB_TOKEN_RE
+        .replace_all(&without_url_creds, "REDACTED")
+        .into_owned()
+}
+
 pub async fn post_annotations(
     ctx: &GhContext,
     annotations: Vec<Annotation>,
@@ -727,6 +752,17 @@ pub async fn post_annotations(
     if annotations.is_empty() {
         return Ok(());
     }
+
+    // Redact once, here, so every caller and every parser is covered and the
+    // summary (built from these messages) inherits it.
+    let annotations: Vec<Annotation> = annotations
+        .into_iter()
+        .map(|a| Annotation {
+            message: redact(&a.message),
+            title: a.title.as_deref().map(redact),
+            ..a
+        })
+        .collect();
 
     let octocrab = Octocrab::builder()
         .personal_token(ctx.token.clone())
@@ -1065,6 +1101,31 @@ thread 'main' panicked at 'boom', src/lib.rs:12:5
             .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
             .collect();
         move |k: &str| map.get(k).cloned()
+    }
+
+    #[test]
+    fn redact_strips_credentials_that_reach_a_public_check_run() {
+        // The URL rewrite CI installs to clone private deps is the realistic
+        // path: a failing fetch echoes the remote, token and all.
+        let msg = "failed to fetch https://x-access-token:ghs_AbCdEfGhIjKlMnOpQrSt@github.com/fslabs/x.git";
+        let out = redact(msg);
+        assert!(!out.contains("ghs_AbCdEfGhIjKlMnOpQrSt"), "{out}");
+        assert!(
+            out.contains("https://x-access-token:REDACTED@github.com/"),
+            "{out}"
+        );
+
+        // Bare tokens, wherever they appear.
+        assert_eq!(
+            redact("token ghp_0123456789abcdefghij here"),
+            "token REDACTED here"
+        );
+        assert!(!redact("github_pat_11ABCDEFG0123456789_abcdefgh").contains("11ABCDEFG"));
+
+        // Ordinary diagnostics must survive untouched, including URLs with no
+        // credentials and colons that are not userinfo.
+        let plain = "error[E0308]: mismatched types at https://docs.rs/foo/1.0/foo.html";
+        assert_eq!(redact(plain), plain);
     }
 
     #[test]

--- a/src/commands/tests/annotations.rs
+++ b/src/commands/tests/annotations.rs
@@ -3,8 +3,13 @@
 //!
 //! Conclusion is always `neutral`: this reports locations, not verdicts.
 //! Prow's own `cargo-tests` check is the pass/fail gate. Posting is a no-op
-//! outside Prow (any of `REPO_OWNER`, `REPO_NAME`, `PULL_PULL_SHA`, or
-//! `GITHUB_TOKEN` missing, or `FSLABSCLI_ANNOTATIONS_DISABLE=1`).
+//! outside Prow (any of `REPO_OWNER`, `REPO_NAME` or `PULL_PULL_SHA` missing,
+//! or `FSLABSCLI_ANNOTATIONS_DISABLE=1`).
+//!
+//! The credential is either `GITHUB_TOKEN` or a GitHub App key, from which we
+//! mint an installation token scoped to the repository under test. CI uses the
+//! App: the token is short-lived and cannot reach any other repo, which matters
+//! because this runs in a pod that compiles unreviewed pull-request code.
 //!
 //! API: <https://docs.github.com/en/rest/checks/runs>
 
@@ -19,6 +24,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex};
 
 use crate::script::CommandOutput;
+use crate::utils::github::{InstallationRetrievalMode, generate_github_app_token};
 
 // GitHub caps a single check-runs API call at 50 annotations.
 const MAX_ANNOTATIONS_PER_CALL: usize = 50;
@@ -387,19 +393,43 @@ fn lexical_normalize(p: &Path) -> PathBuf {
     out
 }
 
-pub struct GhContext {
+/// Which commit in which repository the check run describes. Holds no
+/// credential, so it can be resolved from the environment before we know where
+/// the token is coming from.
+#[derive(Debug)]
+pub struct GhTarget {
     pub owner: String,
     pub repo: String,
     pub head_sha: String,
-    pub token: String,
     /// PR number, used to construct diff-view anchors. `None` on non-presubmit
     /// runs (postsubmit, periodic); in that case the summary falls back to
     /// blob-view links.
     pub pull_number: Option<u64>,
 }
 
-impl GhContext {
-    pub fn from_env() -> Option<Self> {
+/// Why there is nothing to post to. Carried as a value rather than a bare
+/// `None` so the caller can log the specific thing that is missing; the
+/// original code logged all five candidates at once, at `debug!`, and the
+/// feature sat silently disabled in CI for twelve days as a result.
+#[derive(Debug, PartialEq, Eq)]
+pub enum NoTarget {
+    Disabled,
+    Missing(Vec<&'static str>),
+}
+
+impl std::fmt::Display for NoTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Disabled => write!(f, "FSLABSCLI_ANNOTATIONS_DISABLE is set"),
+            Self::Missing(vars) => {
+                write!(f, "{} unset (not running under Prow?)", vars.join(", "))
+            }
+        }
+    }
+}
+
+impl GhTarget {
+    pub fn from_env() -> Result<Self, NoTarget> {
         Self::from_env_with(|k| std::env::var(k).ok())
     }
 
@@ -408,22 +438,81 @@ impl GhContext {
     /// can exercise the missing-var / empty-string / present-value shapes with
     /// a HashMap-backed getter instead of mutating the shared process env
     /// (mutation would race with any parallel test that reads REPO_OWNER etc).
-    pub fn from_env_with(get: impl Fn(&str) -> Option<String>) -> Option<Self> {
+    pub fn from_env_with(get: impl Fn(&str) -> Option<String>) -> Result<Self, NoTarget> {
         let get_nonempty = |k: &str| get(k).filter(|s| !s.is_empty());
         if get("FSLABSCLI_ANNOTATIONS_DISABLE")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false)
         {
-            return None;
+            return Err(NoTarget::Disabled);
         }
-        Some(Self {
-            owner: get_nonempty("REPO_OWNER")?,
-            repo: get_nonempty("REPO_NAME")?,
-            head_sha: get_nonempty("PULL_PULL_SHA").or_else(|| get_nonempty("PULL_BASE_SHA"))?,
-            token: get_nonempty("GITHUB_TOKEN")?,
-            pull_number: get_nonempty("PULL_NUMBER").and_then(|v| v.parse().ok()),
-        })
+        let owner = get_nonempty("REPO_OWNER");
+        let repo = get_nonempty("REPO_NAME");
+        let head_sha = get_nonempty("PULL_PULL_SHA").or_else(|| get_nonempty("PULL_BASE_SHA"));
+
+        let mut missing = Vec::new();
+        if owner.is_none() {
+            missing.push("REPO_OWNER");
+        }
+        if repo.is_none() {
+            missing.push("REPO_NAME");
+        }
+        if head_sha.is_none() {
+            missing.push("PULL_PULL_SHA");
+        }
+
+        match (owner, repo, head_sha) {
+            (Some(owner), Some(repo), Some(head_sha)) => Ok(Self {
+                owner,
+                repo,
+                head_sha,
+                pull_number: get_nonempty("PULL_NUMBER").and_then(|v| v.parse().ok()),
+            }),
+            _ => Err(NoTarget::Missing(missing)),
+        }
     }
+}
+
+pub struct GhContext {
+    pub target: GhTarget,
+    pub token: String,
+}
+
+/// Obtain a credential for the check-runs API.
+///
+/// Prefers `GITHUB_TOKEN` when the job already has one. Otherwise mints an
+/// installation token from a GitHub App key, scoped with
+/// [`InstallationRetrievalMode::Repository`] to the repository under test, so
+/// the credential a test pod holds cannot write anywhere else in the org.
+pub async fn resolve_token(
+    target: &GhTarget,
+    app_id: Option<u64>,
+    app_private_key: Option<&Path>,
+) -> Result<String> {
+    if let Some(token) = std::env::var("GITHUB_TOKEN").ok().filter(|s| !s.is_empty()) {
+        return Ok(token);
+    }
+    let (Some(app_id), Some(key_path)) = (app_id, app_private_key) else {
+        anyhow::bail!(
+            "no GITHUB_TOKEN, and no GitHub App to mint one from \
+             (set FSLABSCLI_CHECKS_APP_ID and FSLABSCLI_CHECKS_APP_PRIVATE_KEY)"
+        );
+    };
+    generate_github_app_token(
+        app_id,
+        key_path.to_path_buf(),
+        InstallationRetrievalMode::Repository,
+        Some(format!("{}/{}", target.owner, target.repo)),
+    )
+    .await
+    .with_context(|| {
+        format!(
+            "mint a checks token for {}/{} from app {app_id} (key {})",
+            target.owner,
+            target.repo,
+            key_path.display(),
+        )
+    })
 }
 
 /// Build a click-through URL for one annotation. Prefers the PR files-diff
@@ -432,7 +521,7 @@ impl GhContext {
 /// the failing line WITH the annotation banner still visible. Falls back to
 /// the blob view when there's no PR number (postsubmit, periodic) - the
 /// anchor is stable but no annotation banner is drawn.
-fn annotation_url(ctx: &GhContext, path: &str, line: u32) -> String {
+fn annotation_url(ctx: &GhTarget, path: &str, line: u32) -> String {
     match ctx.pull_number {
         Some(pr) => {
             let mut hasher = Sha256::new();
@@ -532,7 +621,7 @@ fn prow_log_url_with(get: impl Fn(&str) -> Option<String>) -> Option<String> {
 /// reproduce command, prow log link (when in Prow), per-package test summary,
 /// findings grouped by tool, rerun instructions. Each `file:line` links into
 /// GitHub's blob view at the PR head SHA so a click lands on the exact line.
-fn build_summary(ctx: &GhContext, annotations: &[Annotation], junit: &Report) -> String {
+fn build_summary(ctx: &GhTarget, annotations: &[Annotation], junit: &Report) -> String {
     use std::collections::BTreeMap;
     let failures = annotations
         .iter()
@@ -644,9 +733,9 @@ pub async fn post_annotations(
         .build()
         .context("build octocrab client")?;
 
-    let path = format!("/repos/{}/{}/check-runs", ctx.owner, ctx.repo);
+    let path = format!("/repos/{}/{}/check-runs", ctx.target.owner, ctx.target.repo);
     let title = "Test summary".to_string();
-    let summary = build_summary(ctx, &annotations, junit);
+    let summary = build_summary(&ctx.target, &annotations, junit);
 
     let mut chunks = annotations.chunks(MAX_ANNOTATIONS_PER_CALL);
     let first = chunks.next().unwrap_or(&[]);
@@ -655,7 +744,7 @@ pub async fn post_annotations(
     // check already shows failure; a second red X here adds no information.
     let body = json!({
         "name": CHECK_NAME,
-        "head_sha": ctx.head_sha,
+        "head_sha": ctx.target.head_sha,
         "status": "completed",
         "conclusion": "neutral",
         "output": {
@@ -677,7 +766,7 @@ pub async fn post_annotations(
 
     let update_path = format!(
         "/repos/{}/{}/check-runs/{}",
-        ctx.owner, ctx.repo, created.id
+        ctx.target.owner, ctx.target.repo, created.id
     );
     for chunk in chunks {
         let body = json!({
@@ -758,18 +847,17 @@ thread 'main' panicked at 'boom', src/lib.rs:12:5
         assert_eq!(a[0].path, "crates/foo/Cargo.lock");
     }
 
-    fn fake_ctx() -> GhContext {
-        GhContext {
+    fn fake_ctx() -> GhTarget {
+        GhTarget {
             owner: "acme".into(),
             repo: "widget".into(),
             head_sha: "cafef00d".into(),
-            token: "unused".into(),
             pull_number: Some(322),
         }
     }
 
-    fn fake_ctx_no_pr() -> GhContext {
-        GhContext {
+    fn fake_ctx_no_pr() -> GhTarget {
+        GhTarget {
             pull_number: None,
             ..fake_ctx()
         }
@@ -980,32 +1068,48 @@ thread 'main' panicked at 'boom', src/lib.rs:12:5
     }
 
     #[test]
-    fn from_env_returns_none_when_required_var_missing() {
-        // Nothing set at all.
-        assert!(GhContext::from_env_with(env_from(&[])).is_none());
-        // Everything except GITHUB_TOKEN set.
-        let g = GhContext::from_env_with(env_from(&[
+    fn from_env_names_every_missing_var() {
+        // The reason has to name the specific variables: a caller that can only
+        // say "something was missing" is what let this sit broken unnoticed.
+        let err = GhTarget::from_env_with(env_from(&[])).unwrap_err();
+        assert_eq!(
+            err,
+            NoTarget::Missing(vec!["REPO_OWNER", "REPO_NAME", "PULL_PULL_SHA"])
+        );
+        let err = GhTarget::from_env_with(env_from(&[
+            ("REPO_OWNER", "acme"),
+            ("PULL_PULL_SHA", "sha"),
+        ]))
+        .unwrap_err();
+        assert_eq!(err, NoTarget::Missing(vec!["REPO_NAME"]));
+    }
+
+    #[test]
+    fn from_env_does_not_require_a_token() {
+        // The credential is resolved separately (env var or GitHub App), so a
+        // target must build without GITHUB_TOKEN present.
+        let t = GhTarget::from_env_with(env_from(&[
             ("REPO_OWNER", "acme"),
             ("REPO_NAME", "widget"),
             ("PULL_PULL_SHA", "sha"),
-        ]));
-        assert!(g.is_none());
+        ]))
+        .unwrap();
+        assert_eq!(t.owner, "acme");
     }
 
     #[test]
     fn from_env_rejects_empty_string_env_var() {
         // Regression: env::var("X") returns Ok("") for an empty-string value,
-        // so a naive .ok()? would build a GhContext with an empty owner and
-        // POST to /repos//<empty>/check-runs (422). All required vars must
-        // treat "" the same as unset.
+        // so a naive .ok()? would build a target with an empty owner and POST
+        // to /repos//<empty>/check-runs (422). All required vars must treat ""
+        // the same as unset.
         let base = &[
             ("REPO_OWNER", "acme"),
             ("REPO_NAME", "widget"),
             ("PULL_PULL_SHA", "sha"),
-            ("GITHUB_TOKEN", "tok"),
         ];
-        assert!(GhContext::from_env_with(env_from(base)).is_some());
-        for empty_key in ["REPO_OWNER", "REPO_NAME", "PULL_PULL_SHA", "GITHUB_TOKEN"] {
+        assert!(GhTarget::from_env_with(env_from(base)).is_ok());
+        for empty_key in ["REPO_OWNER", "REPO_NAME", "PULL_PULL_SHA"] {
             let mut pairs = base.to_vec();
             for (k, v) in pairs.iter_mut() {
                 if k == &empty_key {
@@ -1013,19 +1117,18 @@ thread 'main' panicked at 'boom', src/lib.rs:12:5
                 }
             }
             assert!(
-                GhContext::from_env_with(env_from(&pairs)).is_none(),
-                "expected None when {empty_key} is empty"
+                GhTarget::from_env_with(env_from(&pairs)).is_err(),
+                "expected an error when {empty_key} is empty"
             );
         }
     }
 
     #[test]
     fn from_env_falls_back_to_pull_base_sha() {
-        let g = GhContext::from_env_with(env_from(&[
+        let g = GhTarget::from_env_with(env_from(&[
             ("REPO_OWNER", "acme"),
             ("REPO_NAME", "widget"),
             ("PULL_BASE_SHA", "basesha"),
-            ("GITHUB_TOKEN", "tok"),
         ]))
         .unwrap();
         assert_eq!(g.head_sha, "basesha");
@@ -1034,15 +1137,15 @@ thread 'main' panicked at 'boom', src/lib.rs:12:5
 
     #[test]
     fn from_env_disable_flag_short_circuits() {
-        // Even when every other var is valid, the disable flag returns None.
-        let g = GhContext::from_env_with(env_from(&[
+        // Even when every other var is valid, the disable flag wins.
+        let err = GhTarget::from_env_with(env_from(&[
             ("FSLABSCLI_ANNOTATIONS_DISABLE", "1"),
             ("REPO_OWNER", "acme"),
             ("REPO_NAME", "widget"),
             ("PULL_PULL_SHA", "sha"),
-            ("GITHUB_TOKEN", "tok"),
-        ]));
-        assert!(g.is_none());
+        ]))
+        .unwrap_err();
+        assert_eq!(err, NoTarget::Disabled);
     }
 
     #[test]

--- a/src/commands/tests/mod.rs
+++ b/src/commands/tests/mod.rs
@@ -2,7 +2,7 @@ mod annotations;
 mod docker_service;
 
 use crate::commands::tests::annotations::{
-    AnnotationCollector, GhContext, parse_output_for, post_annotations,
+    AnnotationCollector, GhContext, GhTarget, parse_output_for, post_annotations, resolve_token,
 };
 
 use anyhow::Context;
@@ -96,6 +96,13 @@ pub struct Options {
     /// Run tests on all packages, ignoring change detection
     #[arg(long)]
     run_all: bool,
+    /// App ID of a GitHub App holding `checks: write`, used to post test
+    /// annotations when the job has no `GITHUB_TOKEN`.
+    #[arg(long, env = "FSLABSCLI_CHECKS_APP_ID")]
+    checks_app_id: Option<u64>,
+    /// Path to the private key of the app named by `--checks-app-id`.
+    #[arg(long, env = "FSLABSCLI_CHECKS_APP_PRIVATE_KEY")]
+    checks_app_private_key: Option<PathBuf>,
 }
 
 #[derive(Serialize)]
@@ -828,23 +835,45 @@ pub async fn tests(
 
     let collected_annotations = annotation_collector.drain();
     if !collected_annotations.is_empty() {
-        if let Some(gh) = GhContext::from_env() {
-            let count = collected_annotations.len();
-            match post_annotations(&gh, collected_annotations, &global_junit_report).await {
-                Ok(()) => tracing::info!(
-                    "Posted {} GitHub check-run annotation(s) to {}/{}@{}",
-                    count,
-                    gh.owner,
-                    gh.repo,
-                    gh.head_sha
-                ),
-                Err(e) => tracing::warn!("Failed to post annotations: {:#}", e),
+        let count = collected_annotations.len();
+        // Every failure here is reported at warn! and then dropped. Posting
+        // annotations is a reporting nicety; the job's pass/fail verdict is
+        // decided by global_failed below and must not depend on GitHub being
+        // reachable. But it is logged loudly, because a silent skip is exactly
+        // how this feature shipped disabled and stayed that way.
+        match GhTarget::from_env() {
+            Ok(target) => {
+                match resolve_token(
+                    &target,
+                    options.checks_app_id,
+                    options.checks_app_private_key.as_deref(),
+                )
+                .await
+                {
+                    Ok(token) => {
+                        let gh = GhContext { target, token };
+                        match post_annotations(&gh, collected_annotations, &global_junit_report)
+                            .await
+                        {
+                            Ok(()) => tracing::info!(
+                                "Posted {} GitHub check-run annotation(s) to {}/{}@{}",
+                                count,
+                                gh.target.owner,
+                                gh.target.repo,
+                                gh.target.head_sha
+                            ),
+                            Err(e) => tracing::warn!("Failed to post annotations: {:#}", e),
+                        }
+                    }
+                    Err(e) => tracing::warn!(
+                        "Not posting {count} GitHub check-run annotation(s): {:#}",
+                        e
+                    ),
+                }
             }
-        } else {
-            tracing::debug!(
-                "Skipping GitHub annotations: missing REPO_OWNER / REPO_NAME / \
-                 PULL_PULL_SHA / GITHUB_TOKEN, or FSLABSCLI_ANNOTATIONS_DISABLE is set"
-            );
+            Err(reason) => {
+                tracing::warn!("Not posting {count} GitHub check-run annotation(s): {reason}")
+            }
         }
     }
 

--- a/src/utils/github.rs
+++ b/src/utils/github.rs
@@ -59,7 +59,9 @@ pub async fn generate_github_app_token(
                 installation.access_tokens_url
             }
             InstallationRetrievalMode::Repository => {
-                let (owner, repo) = payload.split_once(':').ok_or_else(|| {
+                // Only `owner:repo` used to parse, while the error asked for
+                // `owner/repo`. Accept either rather than making callers guess.
+                let (owner, repo) = payload.split_once(['/', ':']).ok_or_else(|| {
                     anyhow::anyhow!("Repo is not in format owner/repo: {}", payload)
                 })?;
                 create_access_token.repositories.push(repo.to_string());


### PR DESCRIPTION
## Why

The `test-annotations` check run from #322 has never posted a single annotation. I verified this against eight recent `fsl_libs` PR head SHAs, including two with failed `cargo-tests` runs *after* the 2.46.0 release: zero check runs of any kind.

There is one cause. `GhContext::from_env` requires `GITHUB_TOKEN`, and the Prow `cargo-tests` pod has no GitHub credential at all — `preset-github-token` is not among its labels, so `runner.sh` never mints one. Every run took the skip path.

The reason nobody noticed for twelve days is that the skip logged at `debug!` while the CLI defaults to `info`, and the message listed all five candidate variables rather than naming the missing one.

## What this changes

`GhContext` splits into a credential-free `GhTarget` (owner, repo, head SHA, PR number) plus a token, so the credential no longer has to come from the environment. `resolve_token` prefers `GITHUB_TOKEN` when the job has one, and otherwise mints an installation token from a GitHub App key using the existing `generate_github_app_token`, scoped with `InstallationRetrievalMode::Repository` to the repository under test.

Two new options on the `tests` command, both env-backed: `--checks-app-id` (`FSLABSCLI_CHECKS_APP_ID`) and `--checks-app-private-key` (`FSLABSCLI_CHECKS_APP_PRIVATE_KEY`).

The skip is now `warn!` and names the specific missing input.

Repository-mode payloads accept `owner/repo` as well as `owner:repo`. Only the latter parsed, while the error message asked for the former.

## On the scoping

This matters more than it looks. A `cargo-tests` pod compiles and runs unreviewed pull-request code — `cargo check` alone executes `build.rs` and proc macros from the PR head — so any credential in that pod should be assumed readable by the PR author. Some of the repos this job runs on are public.

The obvious quick fix was to add `preset-github-token` to the job, which is what `bazel-tests` does today. I would rather not: that preset mounts the org GitHub App's *private key* at `/etc/github-app/private_key`, and `runner.sh` mints an org-wide token from it with the app's full permission set. Worse, `fsl_libs` branch protection requires the `cargo-tests` context bound to that same app id (210313), so an exfiltrated key could forge a passing required check.

An app holding only `checks: write`, minting a token scoped to one repository, cannot do any of that.

## Deployment

This does nothing on its own. The infra side needs a GitHub App with only `checks: write`, its key in Vault, and a preset that mounts it into the `cargo-tests` pod. That is a separate change in the infra repo, referenced there.

## Test plan

- [x] `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` clean
- [x] 25 annotations unit tests pass, including three new ones: the reason names every missing variable, a target builds without any token present, and the disable flag still short-circuits
- [x] Existing empty-string regression coverage retained (`env::var` returns `Ok("")`, which must be treated as unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)