### PR TITLE
fix(auto-update): make --fslabscli-version work at all

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -399,12 +399,20 @@ async fn main() -> ExitCode {
         .and_then(|matches| matches.get_one::<bool>("fslabscli_auto_update").cloned())
         .unwrap_or_default();
 
+    // self_update drives blocking HTTP, and dropping that client inside an
+    // async context aborts the process ("Cannot drop a runtime in a context
+    // where blocking is not allowed"). block_in_place hands this thread over to
+    // blocking work, which makes the drop legal.
     if let Some(version) = fslabscli_version {
-        if let Err(err) = utils::auto_update::auto_update(Some(&version)) {
+        if let Err(err) =
+            tokio::task::block_in_place(|| utils::auto_update::auto_update(Some(&version)))
+        {
             eprintln!("Error trying to update to pinned version: {err:?}");
             std::process::exit(1);
         }
-    } else if fslabscli_auto_update && let Err(err) = utils::auto_update::auto_update(None) {
+    } else if fslabscli_auto_update
+        && let Err(err) = tokio::task::block_in_place(|| utils::auto_update::auto_update(None))
+    {
         eprintln!("Error trying to update: {err:?}");
     }
 

--- a/src/utils/auto_update.rs
+++ b/src/utils/auto_update.rs
@@ -102,6 +102,22 @@ fn extract_version_from_tag(tag: &str) -> &str {
     }
 }
 
+/// Tag shapes a release may carry, most likely first.
+///
+/// `draft-release` and `publish` both default to the `{package_name}-{version}`
+/// template, so releases are tagged `cargo-fslabscli-2.47.0`. Deriving the
+/// prefix from `CARGO_PKG_NAME` keeps this in step with that default rather
+/// than restating it. Two April 2026 releases (2.44.0 and 2.45.0) were tagged
+/// `v{version}` instead, so keep that shape as a fallback rather than making
+/// those two unpinnable, and try the bare version last.
+fn candidate_tags(version: &str) -> [String; 3] {
+    [
+        format!("{}-{version}", env!("CARGO_PKG_NAME")),
+        format!("v{version}"),
+        version.to_string(),
+    ]
+}
+
 pub fn auto_update(target_version: Option<&str>) -> Result<(), Box<dyn error::Error>> {
     let checker = self_update::backends::github::Update::configure()
         .repo_owner("fslabs")
@@ -121,9 +137,26 @@ pub fn auto_update(target_version: Option<&str>) -> Result<(), Box<dyn error::Er
             return Ok(());
         }
 
-        let release = checker
-            .get_release_version(&format!("v{normalized}"))
-            .map_err(|_| format!("Requested version {} not found in GitHub releases", version))?;
+        let mut found = None;
+        let mut last_error = None;
+        for tag in candidate_tags(normalized) {
+            match checker.get_release_version(&tag) {
+                Ok(release) => {
+                    found = Some(release);
+                    break;
+                }
+                // Keep the underlying error: swallowing it reported a network
+                // failure or a rate limit as "version not found", which sent
+                // you looking in the wrong place entirely.
+                Err(e) => last_error = Some(format!("{tag}: {e}")),
+            }
+        }
+        let release = found.ok_or_else(|| match last_error {
+            Some(e) => format!(
+                "Requested version {version} not found in GitHub releases (last attempt {e})"
+            ),
+            None => format!("Requested version {version} not found in GitHub releases"),
+        })?;
 
         let release_asset = compatible_targets
             .iter()
@@ -167,6 +200,26 @@ pub fn auto_update(target_version: Option<&str>) -> Result<(), Box<dyn error::Er
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_candidate_tags_tries_the_real_scheme_first() {
+        // Regression: this looked up "v{version}" only, so pinning to any
+        // release tagged cargo-fslabscli-{version} 404'd and, because a failed
+        // pin exits the process, the command never ran at all.
+        let tags = candidate_tags("2.47.0");
+        assert_eq!(tags[0], "cargo-fslabscli-2.47.0");
+        assert_eq!(tags[1], "v2.47.0");
+        assert_eq!(tags[2], "2.47.0");
+    }
+
+    #[test]
+    fn test_candidate_tags_round_trip_through_extract() {
+        // Whatever shape we ask for, parsing it back must yield the version we
+        // started with, so the two halves cannot drift apart.
+        for tag in candidate_tags("2.47.0") {
+            assert_eq!(extract_version_from_tag(&tag), "2.47.0");
+        }
+    }
 
     #[test]
     fn test_extract_version_from_tag_v_prefix() {


### PR DESCRIPTION
Found while investigating why the `test-annotations` check run never posted. Independent of #326 and #327 — this one branches off `main`.

## Two bugs, either of which alone breaks pinning

**Wrong tag scheme.** The lookup asked for `v{version}`, but releases are tagged `cargo-fslabscli-{version}` by the default template in `draft-release` and `publish`. So every pin 404'd except 2.44.0 and 2.45.0, the two releases that happened to be tagged `v` during April 2026.

This is not a soft failure. A failed pin hits `std::process::exit(1)` before `run()` is reached, so `FSLABSCLI_VERSION=2.47.0` does not fall back to running unpinned — it stops the command from running at all.

The candidate list now tries `cargo-fslabscli-{version}` first, keeps `v{version}` so those two releases stay pinnable, and falls back to the bare version. The prefix is derived from `CARGO_PKG_NAME` rather than restated, so it cannot drift from the template `draft-release` uses.

The underlying error was also discarded by `map_err(|_| ...)`, which reported a network failure or a rate limit as "version not found in GitHub releases". That is kept now.

**Blocking client dropped in async context.** `self_update` drives blocking HTTP, and dropping that client inside the async `main` aborts the process:

```
thread 'main' panicked at tokio-1.48.0/src/runtime/blocking/shutdown.rs:51:21:
Cannot drop a runtime in a context where blocking is not allowed.
```

Both update paths hit this on any invocation that reaches the network, so the pinned path could not have worked even with the correct tag. Both calls are now wrapped in `tokio::task::block_in_place`. This reproduces on `main` at `cargo-fslabscli-2.47.0`'s lockfile, so it is not new here.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` clean; full suite green (241 tests)
- [x] Two new unit tests: candidate ordering, and a round-trip asserting every shape we ask for parses back through `extract_version_from_tag` to the version we started with, so the two halves cannot drift
- [x] Verified against the live GitHub API. Pinning 2.46.0 resolves the release and gets as far as asset selection: `Version 2.46.0 found but no pre-built binary for any compatible architecture. Tried: aarch64-apple-darwin` — expected on macOS, since only linux-musl binaries are published
- [x] An unknown version now reports the cause: `Requested version 2.99.0 not found in GitHub releases (last attempt 2.99.0: NetworkError: api request failed with status: 404 ...)`
- [x] Both paths previously aborted with exit 101; both now exit cleanly

## Unrelated bug noticed in passing

`fslabscli completions <shell>` panics in debug builds: generating completions builds every subcommand, which trips a clap assert that `draft-release` has an argument named `version` colliding with the auto-generated `--version` from `propagate_version(true)`. Release builds compile the assert out. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)