### PR TITLE
chore: bump version to 2.48.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.47.0"
+version = "2.48.0"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-fslabscli"
 publish = ["fsl"]
 repository = "https://github.com/fslabs/fslabsci"
-version = "2.47.0"
+version = "2.48.0"
 
 [package.metadata.fslabs.publish.binary]
 name = "FSLABS Cli tool"


### PR DESCRIPTION
Bumps `version` from 2.47.0 to 2.48.0 in `Cargo.toml` and `Cargo.lock`. Minor bump for the two `feat` commits landed on `main` since v2.47.0 (#326, #327).

Needed before anything downstream can move: the release process takes its version from `Cargo.toml`, so until this lands no draft release is cut, and there is no release containing the `annotate` subcommand for `images/prow-tests` and `images/prow-bazel-tests` to pin to.