### PR TITLE
chore(release): bump version to 2.48.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.48.0"
+version = "2.48.1"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-fslabscli"
 publish = ["fsl"]
 repository = "https://github.com/fslabs/fslabsci"
-version = "2.48.0"
+version = "2.48.1"
 
 [package.metadata.fslabs.publish.binary]
 name = "FSLABS Cli tool"


### PR DESCRIPTION
## Summary

- Bump `cargo-fslabscli` from 2.48.0 to 2.48.1.
- Keep the root package entry in `Cargo.lock` synchronized.
- Trigger the documented draft-release workflow after merge.

This patch release contains the Docker service-volume cleanup from #330. The generated release must remain draft until its assets are verified.

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- `RUSTC_WRAPPER= cargo check --locked`
- `git diff --check`
- SSH-signed commit

The `skip-changelog` label keeps this mechanical version bump out of the release notes. The underlying bug fix remains included through #330.
